### PR TITLE
Update to bloc & flutter_bloc 6.0

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -91,7 +91,7 @@ packages:
       name: bloc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.1"
+    version: "6.0.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -232,13 +232,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.16.1"
-  cubit:
-    dependency: transitive
-    description:
-      name: cubit
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -299,14 +292,7 @@ packages:
       name: flutter_bloc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.1"
-  flutter_cubit:
-    dependency: transitive
-    description:
-      name: flutter_cubit
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.1"
+    version: "6.0.0"
   flutter_mobx:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0"
+    version: "6.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.39.13"
+    version: "0.39.14"
   archive:
     dependency: transitive
     description:
@@ -91,7 +91,7 @@ packages:
       name: bloc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.1"
+    version: "6.0.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -176,6 +176,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
+  cli_util:
+    dependency: transitive
+    description:
+      name: cli_util
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   clock:
     dependency: transitive
     description:
@@ -232,13 +239,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.16.1"
-  cubit:
-    dependency: transitive
-    description:
-      name: cubit
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.2"
   dart_style:
     dependency: transitive
     description:
@@ -292,14 +292,7 @@ packages:
       name: flutter_bloc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.1"
-  flutter_cubit:
-    dependency: transitive
-    description:
-      name: flutter_cubit
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.1"
+    version: "6.0.0"
   flutter_secure_storage:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,10 +11,10 @@ dependencies:
     sdk: flutter
   basic_utils: ^2.5.6
   bip39: ^1.0.3
-  bloc: ^5.0.1
+  bloc: ^6.0.0
   commerciosdk: ^2.1.2
   equatable: ^1.2.2
-  flutter_bloc: ^5.0.1
+  flutter_bloc: ^6.0.0
   flutter_secure_storage: ^3.3.3
   freezed_annotation: ^0.11.0
   http: ^0.12.2

--- a/test/ui/account/commercio_account_ui_flat_button_test.dart
+++ b/test/ui/account/commercio_account_ui_flat_button_test.dart
@@ -44,7 +44,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioAccountGenerateWalletInitial>(),
         isA<CommercioAccountGenerateWalletLoading>(),
         isA<CommercioAccountGenerateWalletData>(),
         isA<CommercioAccountGenerateWalletLoading>(),
@@ -109,7 +108,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioAccountRestoredWalletStateInitial>(),
         isA<CommercioAccountRestoredWalletStateLoading>(),
         isA<CommercioAccountRestoredWalletStateData>(),
         isA<CommercioAccountRestoredWalletStateLoading>(),
@@ -174,7 +172,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioAccountRestoredWalletStateInitial>(),
         isA<CommercioAccountRestoredWalletStateLoading>(),
         isA<CommercioAccountRestoredWalletStateData>(),
       ]),
@@ -230,7 +227,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioAccountFreeTokensStateInitial>(),
         isA<CommercioAccountFreeTokensStateLoading>(),
         isA<CommercioAccountFreeTokensStateData>(),
         isA<CommercioAccountFreeTokensStateLoading>(),
@@ -294,7 +290,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioAccountBalanceStateInitial>(),
         isA<CommercioAccountBalanceStateLoading>(),
         isA<CommercioAccountBalanceStateData>(),
         isA<CommercioAccountBalanceStateLoading>(),
@@ -364,7 +359,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioAccountSentTokensStateInitial>(),
         isA<CommercioAccountSentTokensStateLoading>(),
         isA<CommercioAccountSentTokensStateData>(),
         isA<CommercioAccountSentTokensStateLoading>(),
@@ -429,7 +423,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioAccountQrStateInitial>(),
         isA<CommercioAccountQrStateLoading>(),
         isA<CommercioAccountQrStateData>(),
         isA<CommercioAccountQrStateLoading>(),
@@ -489,7 +482,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioAccountPaiwiseWalletStateInitial>(),
         isA<CommercioAccountPaiwiseWalletStateLoading>(),
         isA<CommercioAccountPaiwiseWalletStateData>(),
         isA<CommercioAccountPaiwiseWalletStateLoading>(),

--- a/test/ui/account/commercio_account_ui_text_field_test.dart
+++ b/test/ui/account/commercio_account_ui_text_field_test.dart
@@ -44,7 +44,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioAccountGenerateWalletInitial>(),
         isA<CommercioAccountGenerateWalletLoading>(),
         isA<CommercioAccountGenerateWalletData>(),
         isA<CommercioAccountGenerateWalletLoading>(),
@@ -103,7 +102,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioAccountRestoredWalletStateInitial>(),
         isA<CommercioAccountRestoredWalletStateLoading>(),
         isA<CommercioAccountRestoredWalletStateData>(),
         isA<CommercioAccountRestoredWalletStateLoading>(),
@@ -162,7 +160,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioAccountFreeTokensStateInitial>(),
         isA<CommercioAccountFreeTokensStateLoading>(),
         isA<CommercioAccountFreeTokensStateData>(),
         isA<CommercioAccountFreeTokensStateLoading>(),
@@ -221,7 +218,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioAccountBalanceStateInitial>(),
         isA<CommercioAccountBalanceStateLoading>(),
         isA<CommercioAccountBalanceStateData>(),
         isA<CommercioAccountBalanceStateLoading>(),
@@ -285,7 +281,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioAccountSentTokensStateInitial>(),
         isA<CommercioAccountSentTokensStateLoading>(),
         isA<CommercioAccountSentTokensStateData>(),
         isA<CommercioAccountSentTokensStateLoading>(),
@@ -349,7 +344,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioAccountPaiwiseWalletStateInitial>(),
         isA<CommercioAccountPaiwiseWalletStateLoading>(),
         isA<CommercioAccountPaiwiseWalletStateData>(),
         isA<CommercioAccountPaiwiseWalletStateLoading>(),

--- a/test/ui/account/commercio_account_ui_text_test.dart
+++ b/test/ui/account/commercio_account_ui_text_test.dart
@@ -44,7 +44,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioAccountGenerateWalletInitial>(),
         isA<CommercioAccountGenerateWalletLoading>(),
         isA<CommercioAccountGenerateWalletData>(),
         isA<CommercioAccountGenerateWalletLoading>(),
@@ -103,7 +102,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioAccountRestoredWalletStateInitial>(),
         isA<CommercioAccountRestoredWalletStateLoading>(),
         isA<CommercioAccountRestoredWalletStateData>(),
         isA<CommercioAccountRestoredWalletStateLoading>(),
@@ -162,7 +160,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioAccountFreeTokensStateInitial>(),
         isA<CommercioAccountFreeTokensStateLoading>(),
         isA<CommercioAccountFreeTokensStateData>(),
         isA<CommercioAccountFreeTokensStateLoading>(),
@@ -221,7 +218,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioAccountBalanceStateInitial>(),
         isA<CommercioAccountBalanceStateLoading>(),
         isA<CommercioAccountBalanceStateData>(),
         isA<CommercioAccountBalanceStateLoading>(),
@@ -285,7 +281,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioAccountSentTokensStateInitial>(),
         isA<CommercioAccountSentTokensStateLoading>(),
         isA<CommercioAccountSentTokensStateData>(),
         isA<CommercioAccountSentTokensStateLoading>(),
@@ -349,7 +344,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioAccountPaiwiseWalletStateInitial>(),
         isA<CommercioAccountPaiwiseWalletStateLoading>(),
         isA<CommercioAccountPaiwiseWalletStateData>(),
         isA<CommercioAccountPaiwiseWalletStateLoading>(),

--- a/test/ui/commercio_flat_button_test.dart
+++ b/test/ui/commercio_flat_button_test.dart
@@ -57,12 +57,7 @@ void main() {
   testWidgets('Submit loading event', (WidgetTester tester) async {
     final blocMock = BlocMock();
 
-    expect(
-        blocMock,
-        emitsInOrder([
-          isA<InitialStateMock>(),
-          isA<LoadingStateMock>(),
-        ]));
+    expect(blocMock, emitsInOrder([isA<LoadingStateMock>()]));
 
     final commFlatButton = CommercioFlatButton<BlocMock, EventMock, StateMock,
         LoadingStateMock, ErrorStateMock>(
@@ -96,12 +91,7 @@ void main() {
   testWidgets('Submit data event', (WidgetTester tester) async {
     final blocMock = BlocMock();
 
-    expect(
-        blocMock,
-        emitsInOrder([
-          isA<InitialStateMock>(),
-          isA<DataStateMock>(),
-        ]));
+    expect(blocMock, emitsInOrder([isA<DataStateMock>()]));
 
     final commFlatButton = CommercioFlatButton<BlocMock, EventMock, StateMock,
         LoadingStateMock, ErrorStateMock>(
@@ -135,12 +125,7 @@ void main() {
   testWidgets('Submit error event', (WidgetTester tester) async {
     final blocMock = BlocMock();
 
-    expect(
-        blocMock,
-        emitsInOrder([
-          isA<InitialStateMock>(),
-          isA<ErrorStateMock>(),
-        ]));
+    expect(blocMock, emitsInOrder([isA<ErrorStateMock>()]));
 
     final commFlatButton = CommercioFlatButton<BlocMock, EventMock, StateMock,
         LoadingStateMock, ErrorStateMock>(
@@ -175,12 +160,7 @@ void main() {
   testWidgets('Submit custom error event', (WidgetTester tester) async {
     final blocMock = BlocMock();
 
-    expect(
-        blocMock,
-        emitsInOrder([
-          isA<InitialStateMock>(),
-          isA<ErrorStateMock>(),
-        ]));
+    expect(blocMock, emitsInOrder([isA<ErrorStateMock>()]));
 
     final commFlatButton = CommercioFlatButton<BlocMock, EventMock, StateMock,
         LoadingStateMock, ErrorStateMock>(

--- a/test/ui/commercio_text_field_test.dart
+++ b/test/ui/commercio_text_field_test.dart
@@ -57,7 +57,7 @@ void main() {
   testWidgets('Initial state', (WidgetTester tester) async {
     final blocMock = BlocMock();
 
-    expect(blocMock, emitsInOrder([isA<InitialStateMock>()]));
+    expect(blocMock, emitsInOrder([]));
 
     final commTextField = CommercioTextField<BlocMock, EventMock, StateMock,
         InitialStateMock, DataStateMock, LoadingStateMock, ErrorStateMock>(
@@ -81,12 +81,7 @@ void main() {
   testWidgets('Loading state', (WidgetTester tester) async {
     final blocMock = BlocMock();
 
-    expect(
-        blocMock,
-        emitsInOrder([
-          isA<InitialStateMock>(),
-          isA<LoadingStateMock>(),
-        ]));
+    expect(blocMock, emitsInOrder([isA<LoadingStateMock>()]));
 
     final commTextField = CommercioTextField<BlocMock, EventMock, StateMock,
         InitialStateMock, DataStateMock, LoadingStateMock, ErrorStateMock>(
@@ -110,12 +105,7 @@ void main() {
   testWidgets('Data state', (WidgetTester tester) async {
     final blocMock = BlocMock();
 
-    expect(
-        blocMock,
-        emitsInOrder([
-          isA<InitialStateMock>(),
-          isA<DataStateMock>(),
-        ]));
+    expect(blocMock, emitsInOrder([isA<DataStateMock>()]));
 
     final commTextField = CommercioTextField<BlocMock, EventMock, StateMock,
         InitialStateMock, DataStateMock, LoadingStateMock, ErrorStateMock>(
@@ -139,12 +129,7 @@ void main() {
   testWidgets('Error state', (WidgetTester tester) async {
     final blocMock = BlocMock();
 
-    expect(
-        blocMock,
-        emitsInOrder([
-          isA<InitialStateMock>(),
-          isA<ErrorStateMock>(),
-        ]));
+    expect(blocMock, emitsInOrder([isA<ErrorStateMock>()]));
 
     final commTextField = CommercioTextField<BlocMock, EventMock, StateMock,
         InitialStateMock, DataStateMock, LoadingStateMock, ErrorStateMock>(

--- a/test/ui/commercio_text_test.dart
+++ b/test/ui/commercio_text_test.dart
@@ -57,7 +57,7 @@ void main() {
   testWidgets('Initial state', (WidgetTester tester) async {
     final blocMock = BlocMock();
 
-    expect(blocMock, emitsInOrder([isA<InitialStateMock>()]));
+    expect(blocMock, emitsInOrder([]));
 
     final commText = CommercioText<BlocMock, EventMock, StateMock,
         InitialStateMock, DataStateMock, LoadingStateMock, ErrorStateMock>(
@@ -81,12 +81,7 @@ void main() {
   testWidgets('Loading state', (WidgetTester tester) async {
     final blocMock = BlocMock();
 
-    expect(
-        blocMock,
-        emitsInOrder([
-          isA<InitialStateMock>(),
-          isA<LoadingStateMock>(),
-        ]));
+    expect(blocMock, emitsInOrder([isA<LoadingStateMock>()]));
 
     final commText = CommercioText<BlocMock, EventMock, StateMock,
         InitialStateMock, DataStateMock, LoadingStateMock, ErrorStateMock>(
@@ -110,12 +105,7 @@ void main() {
   testWidgets('Data state', (WidgetTester tester) async {
     final blocMock = BlocMock();
 
-    expect(
-        blocMock,
-        emitsInOrder([
-          isA<InitialStateMock>(),
-          isA<DataStateMock>(),
-        ]));
+    expect(blocMock, emitsInOrder([isA<DataStateMock>()]));
 
     final commText = CommercioText<BlocMock, EventMock, StateMock,
         InitialStateMock, DataStateMock, LoadingStateMock, ErrorStateMock>(

--- a/test/ui/docs/bloc/commercio_docs_bloc_test.dart
+++ b/test/ui/docs/bloc/commercio_docs_bloc_test.dart
@@ -12,7 +12,6 @@ void main() {
       expect(
         bloc,
         emitsInOrder([
-          isA<CommercioDocsEncDataStateInitial>(),
           isA<CommercioDocsEncDataStateLoading>(),
           isA<CommercioDocsEncDataStateData>(),
         ]),

--- a/test/ui/docs/commercio_docs_ui_flat_button_test.dart
+++ b/test/ui/docs/commercio_docs_ui_flat_button_test.dart
@@ -79,7 +79,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioDocsDeriveDocumentStateInitial>(),
         isA<CommercioDocsDeriveDocumentStateLoading>(),
         isA<CommercioDocsDeriveDocumentStateData>(),
         isA<CommercioDocsDeriveDocumentStateLoading>(),
@@ -154,7 +153,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioDocsSharedDocumentsStateInitial>(),
         isA<CommercioDocsSharedDocumentsStateLoading>(),
         isA<CommercioDocsSharedDocumentsStateData>(),
         isA<CommercioDocsSharedDocumentsStateLoading>(),
@@ -223,7 +221,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioDocsDeriveReceiptStateInitial>(),
         isA<CommercioDocsDeriveReceiptStateLoading>(),
         isA<CommercioDocsDeriveReceiptStateData>(),
         isA<CommercioDocsDeriveReceiptStateLoading>(),
@@ -294,7 +291,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioDocsSentReceiptStateInitial>(),
         isA<CommercioDocsSentReceiptStateLoading>(),
         isA<CommercioDocsSentReceiptStateData>(),
         isA<CommercioDocsSentReceiptStateLoading>(),
@@ -358,7 +354,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioDocsSentDocumentsStateInitial>(),
         isA<CommercioDocsSentDocumentsStateLoading>(),
         isA<CommercioDocsSentDocumentsStateData>(),
         isA<CommercioDocsSentDocumentsStateLoading>(),
@@ -418,7 +413,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioDocsReceivedDocumentsStateInitial>(),
         isA<CommercioDocsReceivedDocumentsStateLoading>(),
         isA<CommercioDocsReceivedDocumentsStateData>(),
         isA<CommercioDocsReceivedDocumentsStateLoading>(),
@@ -479,7 +473,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioDocsSentReceiptsStateInitial>(),
         isA<CommercioDocsSentReceiptsStateLoading>(),
         isA<CommercioDocsSentReceiptsStateData>(),
         isA<CommercioDocsSentReceiptsStateLoading>(),
@@ -539,7 +532,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioDocsReceivedReceiptsStateInitial>(),
         isA<CommercioDocsReceivedReceiptsStateLoading>(),
         isA<CommercioDocsReceivedReceiptsStateData>(),
         isA<CommercioDocsReceivedReceiptsStateLoading>(),

--- a/test/ui/docs/commercio_docs_ui_text_field_test.dart
+++ b/test/ui/docs/commercio_docs_ui_text_field_test.dart
@@ -85,7 +85,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioDocsDeriveDocumentStateInitial>(),
         isA<CommercioDocsDeriveDocumentStateLoading>(),
         isA<CommercioDocsDeriveDocumentStateData>(),
         isA<CommercioDocsDeriveDocumentStateLoading>(),
@@ -159,7 +158,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioDocsSharedDocumentsStateInitial>(),
         isA<CommercioDocsSharedDocumentsStateLoading>(),
         isA<CommercioDocsSharedDocumentsStateData>(),
         isA<CommercioDocsSharedDocumentsStateLoading>(),
@@ -225,7 +223,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioDocsDeriveReceiptStateInitial>(),
         isA<CommercioDocsDeriveReceiptStateLoading>(),
         isA<CommercioDocsDeriveReceiptStateData>(),
         isA<CommercioDocsDeriveReceiptStateLoading>(),
@@ -296,7 +293,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioDocsSentReceiptStateInitial>(),
         isA<CommercioDocsSentReceiptStateLoading>(),
         isA<CommercioDocsSentReceiptStateData>(),
         isA<CommercioDocsSentReceiptStateLoading>(),
@@ -357,7 +353,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioDocsSentDocumentsStateInitial>(),
         isA<CommercioDocsSentDocumentsStateLoading>(),
         isA<CommercioDocsSentDocumentsStateData>(),
         isA<CommercioDocsSentDocumentsStateLoading>(),
@@ -412,7 +407,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioDocsReceivedDocumentsStateInitial>(),
         isA<CommercioDocsReceivedDocumentsStateLoading>(),
         isA<CommercioDocsReceivedDocumentsStateData>(),
         isA<CommercioDocsReceivedDocumentsStateLoading>(),
@@ -468,7 +462,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioDocsSentReceiptsStateInitial>(),
         isA<CommercioDocsSentReceiptsStateLoading>(),
         isA<CommercioDocsSentReceiptsStateData>(),
         isA<CommercioDocsSentReceiptsStateLoading>(),
@@ -523,7 +516,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioDocsReceivedReceiptsStateInitial>(),
         isA<CommercioDocsReceivedReceiptsStateLoading>(),
         isA<CommercioDocsReceivedReceiptsStateData>(),
         isA<CommercioDocsReceivedReceiptsStateLoading>(),

--- a/test/ui/docs/commercio_docs_ui_text_test.dart
+++ b/test/ui/docs/commercio_docs_ui_text_test.dart
@@ -79,7 +79,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioDocsDeriveDocumentStateInitial>(),
         isA<CommercioDocsDeriveDocumentStateLoading>(),
         isA<CommercioDocsDeriveDocumentStateData>(),
         isA<CommercioDocsDeriveDocumentStateLoading>(),
@@ -153,7 +152,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioDocsSharedDocumentsStateInitial>(),
         isA<CommercioDocsSharedDocumentsStateLoading>(),
         isA<CommercioDocsSharedDocumentsStateData>(),
         isA<CommercioDocsSharedDocumentsStateLoading>(),
@@ -219,7 +217,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioDocsDeriveReceiptStateInitial>(),
         isA<CommercioDocsDeriveReceiptStateLoading>(),
         isA<CommercioDocsDeriveReceiptStateData>(),
         isA<CommercioDocsDeriveReceiptStateLoading>(),
@@ -290,7 +287,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioDocsSentReceiptStateInitial>(),
         isA<CommercioDocsSentReceiptStateLoading>(),
         isA<CommercioDocsSentReceiptStateData>(),
         isA<CommercioDocsSentReceiptStateLoading>(),
@@ -351,7 +347,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioDocsSentDocumentsStateInitial>(),
         isA<CommercioDocsSentDocumentsStateLoading>(),
         isA<CommercioDocsSentDocumentsStateData>(),
         isA<CommercioDocsSentDocumentsStateLoading>(),
@@ -406,7 +401,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioDocsReceivedDocumentsStateInitial>(),
         isA<CommercioDocsReceivedDocumentsStateLoading>(),
         isA<CommercioDocsReceivedDocumentsStateData>(),
         isA<CommercioDocsReceivedDocumentsStateLoading>(),
@@ -462,7 +456,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioDocsSentReceiptsStateInitial>(),
         isA<CommercioDocsSentReceiptsStateLoading>(),
         isA<CommercioDocsSentReceiptsStateData>(),
         isA<CommercioDocsSentReceiptsStateLoading>(),
@@ -517,7 +510,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioDocsReceivedReceiptsStateInitial>(),
         isA<CommercioDocsReceivedReceiptsStateLoading>(),
         isA<CommercioDocsReceivedReceiptsStateData>(),
         isA<CommercioDocsReceivedReceiptsStateLoading>(),

--- a/test/ui/id/commercio_id_ui_flat_button_test.dart
+++ b/test/ui/id/commercio_id_ui_flat_button_test.dart
@@ -60,7 +60,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdGeneratedKeysStateInitial>(),
         isA<CommercioIdGeneratedKeysStateLoading>(),
         isA<CommercioIdGeneratedKeysStateData>(),
         isA<CommercioIdGeneratedKeysStateLoading>(),
@@ -119,7 +118,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdRestoredKeysStateInitial>(),
         isA<CommercioIdRestoredKeysStateLoading>(),
         isA<CommercioIdRestoredKeysStateData>(),
         isA<CommercioIdRestoredKeysStateLoading>(),
@@ -177,7 +175,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdDeletedKeysStateInitial>(),
         isA<CommercioIdDeletedKeysStateLoading>(),
         isA<CommercioIdDeletedKeysStateData>(),
         isA<CommercioIdDeletedKeysStateLoading>(),
@@ -236,7 +233,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdDerivedDidDocumentStateInitial>(),
         isA<CommercioIdDerivedDidDocumentStateLoading>(),
         isA<CommercioIdDerivedDidDocumentStateData>(),
         isA<CommercioIdDerivedDidDocumentStateLoading>(),
@@ -296,7 +292,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdSetDidDocumentsStateInitial>(),
         isA<CommercioIdSetDidDocumentsStateLoading>(),
         isA<CommercioIdSetDidDocumentsStateData>(),
         isA<CommercioIdSetDidDocumentsStateLoading>(),
@@ -360,7 +355,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdSetDidDocumentsStateInitial>(),
         isA<CommercioIdSetDidDocumentsStateLoading>(),
         isA<CommercioIdSetDidDocumentsStateData>(),
       ]),
@@ -414,7 +408,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdRechargedTumblerStateInitial>(),
         isA<CommercioIdRechargedTumblerStateLoading>(),
         isA<CommercioIdRechargedTumblerStateData>(),
         isA<CommercioIdRechargedTumblerStateLoading>(),
@@ -485,7 +478,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdRechargedTumblerStateInitial>(),
         isA<CommercioIdRechargedTumblerStateLoading>(),
         isA<CommercioIdRechargedTumblerStateData>(),
       ]),
@@ -540,7 +532,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdDeriveDidPowerUpRequestStateInitial>(),
         isA<CommercioIdDeriveDidPowerUpRequestState>(),
         isA<CommercioIdDeriveDidPowerUpRequestStateData>(),
         isA<CommercioIdDeriveDidPowerUpRequestStateLoading>(),
@@ -606,7 +597,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdRequestedDidPowerUpsStateInitial>(),
         isA<CommercioIdRequestedDidPowerUpsStateLoading>(),
         isA<CommercioIdRequestedDidPowerUpsStateData>(),
         isA<CommercioIdRequestedDidPowerUpsStateLoading>(),

--- a/test/ui/id/commercio_id_ui_text_field_test.dart
+++ b/test/ui/id/commercio_id_ui_text_field_test.dart
@@ -60,7 +60,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdGeneratedKeysStateInitial>(),
         isA<CommercioIdGeneratedKeysStateLoading>(),
         isA<CommercioIdGeneratedKeysStateData>(),
         isA<CommercioIdGeneratedKeysStateLoading>(),
@@ -114,7 +113,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdRestoredKeysStateInitial>(),
         isA<CommercioIdRestoredKeysStateLoading>(),
         isA<CommercioIdRestoredKeysStateData>(),
         isA<CommercioIdRestoredKeysStateLoading>(),
@@ -167,7 +165,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdDeletedKeysStateInitial>(),
         isA<CommercioIdDeletedKeysStateLoading>(),
         isA<CommercioIdDeletedKeysStateData>(),
         isA<CommercioIdDeletedKeysStateLoading>(),
@@ -221,7 +218,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdDerivedDidDocumentStateInitial>(),
         isA<CommercioIdDerivedDidDocumentStateLoading>(),
         isA<CommercioIdDerivedDidDocumentStateData>(),
         isA<CommercioIdDerivedDidDocumentStateLoading>(),
@@ -276,7 +272,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdSetDidDocumentsStateInitial>(),
         isA<CommercioIdSetDidDocumentsStateLoading>(),
         isA<CommercioIdSetDidDocumentsStateData>(),
         isA<CommercioIdSetDidDocumentsStateLoading>(),
@@ -336,7 +331,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdRechargedTumblerStateInitial>(),
         isA<CommercioIdRechargedTumblerStateLoading>(),
         isA<CommercioIdRechargedTumblerStateData>(),
         isA<CommercioIdRechargedTumblerStateLoading>(),
@@ -398,7 +392,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdDeriveDidPowerUpRequestStateInitial>(),
         isA<CommercioIdDeriveDidPowerUpRequestStateLoading>(),
         isA<CommercioIdDeriveDidPowerUpRequestStateData>(),
         isA<CommercioIdDeriveDidPowerUpRequestStateLoading>(),
@@ -462,7 +455,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdRequestedDidPowerUpsStateInitial>(),
         isA<CommercioIdRequestedDidPowerUpsStateLoading>(),
         isA<CommercioIdRequestedDidPowerUpsStateData>(),
         isA<CommercioIdRequestedDidPowerUpsStateLoading>(),

--- a/test/ui/id/commercio_id_ui_text_test.dart
+++ b/test/ui/id/commercio_id_ui_text_test.dart
@@ -60,7 +60,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdGeneratedKeysStateInitial>(),
         isA<CommercioIdGeneratedKeysStateLoading>(),
         isA<CommercioIdGeneratedKeysStateData>(),
         isA<CommercioIdGeneratedKeysStateLoading>(),
@@ -114,7 +113,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdRestoredKeysStateInitial>(),
         isA<CommercioIdRestoredKeysStateLoading>(),
         isA<CommercioIdRestoredKeysStateData>(),
         isA<CommercioIdRestoredKeysStateLoading>(),
@@ -167,7 +165,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdDeletedKeysStateInitial>(),
         isA<CommercioIdDeletedKeysStateLoading>(),
         isA<CommercioIdDeletedKeysStateData>(),
         isA<CommercioIdDeletedKeysStateLoading>(),
@@ -221,7 +218,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdDerivedDidDocumentStateInitial>(),
         isA<CommercioIdDerivedDidDocumentStateLoading>(),
         isA<CommercioIdDerivedDidDocumentStateData>(),
         isA<CommercioIdDerivedDidDocumentStateLoading>(),
@@ -276,7 +272,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdSetDidDocumentsStateInitial>(),
         isA<CommercioIdSetDidDocumentsStateLoading>(),
         isA<CommercioIdSetDidDocumentsStateData>(),
         isA<CommercioIdSetDidDocumentsStateLoading>(),
@@ -338,7 +333,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdRechargedTumblerStateInitial>(),
         isA<CommercioIdRechargedTumblerStateLoading>(),
         isA<CommercioIdRechargedTumblerStateData>(),
         isA<CommercioIdRechargedTumblerStateLoading>(),
@@ -400,7 +394,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdDeriveDidPowerUpRequestStateInitial>(),
         isA<CommercioIdDeriveDidPowerUpRequestStateLoading>(),
         isA<CommercioIdDeriveDidPowerUpRequestStateData>(),
         isA<CommercioIdDeriveDidPowerUpRequestStateLoading>(),
@@ -464,7 +457,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioIdRequestedDidPowerUpsStateInitial>(),
         isA<CommercioIdRequestedDidPowerUpsStateLoading>(),
         isA<CommercioIdRequestedDidPowerUpsStateData>(),
         isA<CommercioIdRequestedDidPowerUpsStateLoading>(),

--- a/test/ui/kyc/bloc/commercio_kyc_bloc_test.dart
+++ b/test/ui/kyc/bloc/commercio_kyc_bloc_test.dart
@@ -11,7 +11,6 @@ void main() {
       expect(
         bloc,
         emitsInOrder([
-          isA<CommercioKycChangeMembershipStateInitial>(),
           CommercioKycChangedMembershipState(
             membershipType: MembershipType.BLACK,
           ),

--- a/test/ui/kyc/commercio_kyc_ui_flat_button_test.dart
+++ b/test/ui/kyc/commercio_kyc_ui_flat_button_test.dart
@@ -50,7 +50,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioKycRequestedFaucetInviteStateInitial>(),
         isA<CommercioKycRequestedFaucetInviteStateLoading>(),
         isA<CommercioKycRequestedFaucetInviteStateData>(),
         isA<CommercioKycRequestedFaucetInviteStateLoading>(),
@@ -110,7 +109,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioKycDeriveBuyMembershipStateInitial>(),
         isA<CommercioKycDeriveBuyMembershipStateLoading>(),
         isA<CommercioKycDeriveBuyMembershipStateData>(),
         isA<CommercioKycDeriveBuyMembershipStateLoading>(),
@@ -174,7 +172,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioKycBuyMembershipsStateInitial>(),
         isA<CommercioKycBuyMembershipsStateLoading>(),
         isA<CommercioKycBuyMembershipsStateData>(),
         isA<CommercioKycBuyMembershipsStateLoading>(),
@@ -238,7 +235,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioKycDeriveInviteMemberStateInitial>(),
         isA<CommercioKycDeriveInviteMemberStateLoading>(),
         isA<CommercioKycDeriveInviteMemberStateData>(),
         isA<CommercioKycDeriveInviteMemberStateLoading>(),
@@ -302,7 +298,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioKycInviteMembersStateInitial>(),
         isA<CommercioKycInviteMembersStateLoading>(),
         isA<CommercioKycInviteMembersStateData>(),
         isA<CommercioKycInviteMembersStateLoading>(),

--- a/test/ui/kyc/commercio_kyc_ui_text_field_test.dart
+++ b/test/ui/kyc/commercio_kyc_ui_text_field_test.dart
@@ -50,7 +50,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioKycRequestedFaucetInviteStateInitial>(),
         isA<CommercioKycRequestedFaucetInviteStateLoading>(),
         isA<CommercioKycRequestedFaucetInviteStateData>(),
         isA<CommercioKycRequestedFaucetInviteStateLoading>(),
@@ -105,7 +104,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioKycDeriveBuyMembershipStateInitial>(),
         isA<CommercioKycDeriveBuyMembershipStateLoading>(),
         isA<CommercioKycDeriveBuyMembershipStateData>(),
         isA<CommercioKycDeriveBuyMembershipStateLoading>(),
@@ -166,7 +164,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioKycBuyMembershipsStateInitial>(),
         isA<CommercioKycBuyMembershipsStateLoading>(),
         isA<CommercioKycBuyMembershipsStateData>(),
         isA<CommercioKycBuyMembershipsStateLoading>(),
@@ -227,7 +224,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioKycDeriveInviteMemberStateInitial>(),
         isA<CommercioKycDeriveInviteMemberStateLoading>(),
         isA<CommercioKycDeriveInviteMemberStateData>(),
         isA<CommercioKycDeriveInviteMemberStateLoading>(),
@@ -288,7 +284,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioKycInviteMembersStateInitial>(),
         isA<CommercioKycInviteMembersStateLoading>(),
         isA<CommercioKycInviteMembersStateData>(),
         isA<CommercioKycInviteMembersStateLoading>(),

--- a/test/ui/kyc/commercio_kyc_ui_text_test.dart
+++ b/test/ui/kyc/commercio_kyc_ui_text_test.dart
@@ -50,7 +50,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioKycRequestedFaucetInviteStateInitial>(),
         isA<CommercioKycRequestedFaucetInviteStateLoading>(),
         isA<CommercioKycRequestedFaucetInviteStateData>(),
         isA<CommercioKycRequestedFaucetInviteStateLoading>(),
@@ -105,7 +104,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioKycDeriveBuyMembershipStateInitial>(),
         isA<CommercioKycDeriveBuyMembershipStateLoading>(),
         isA<CommercioKycDeriveBuyMembershipStateData>(),
         isA<CommercioKycDeriveBuyMembershipStateLoading>(),
@@ -166,7 +164,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioKycBuyMembershipsStateInitial>(),
         isA<CommercioKycBuyMembershipsStateLoading>(),
         isA<CommercioKycBuyMembershipsStateData>(),
         isA<CommercioKycBuyMembershipsStateLoading>(),
@@ -227,7 +224,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioKycDeriveInviteMemberStateInitial>(),
         isA<CommercioKycDeriveInviteMemberStateLoading>(),
         isA<CommercioKycDeriveInviteMemberStateData>(),
         isA<CommercioKycDeriveInviteMemberStateLoading>(),
@@ -288,7 +284,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioKycInviteMembersStateInitial>(),
         isA<CommercioKycInviteMembersStateLoading>(),
         isA<CommercioKycInviteMembersStateData>(),
         isA<CommercioKycInviteMembersStateLoading>(),

--- a/test/ui/kyc/commercio_membership_type_chooser_test.dart
+++ b/test/ui/kyc/commercio_membership_type_chooser_test.dart
@@ -13,7 +13,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioKycChangeMembershipStateInitial>(),
         CommercioKycChangedMembershipState(
           membershipType: MembershipType.BLACK,
         ),

--- a/test/ui/mint/commercio_mint_ui_flat_button_test.dart
+++ b/test/ui/mint/commercio_mint_ui_flat_button_test.dart
@@ -35,7 +35,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioMintOpenedCdpStateInitial>(),
         isA<CommercioMintOpenedCdpStateLoading>(),
         isA<CommercioMintOpenedCdpStateData>(),
         isA<CommercioMintOpenedCdpStateLoading>(),
@@ -95,7 +94,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioMintDeriveCloseCdpStateInitial>(),
         isA<CommercioMintDeriveCloseCdpStateLoading>(),
         isA<CommercioMintDeriveCloseCdpStateData>(),
         isA<CommercioMintDeriveCloseCdpStateLoading>(),
@@ -157,7 +155,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioMintClosedCdpsStateInitial>(),
         isA<CommercioMintClosedCdpsStateLoading>(),
         isA<CommercioMintClosedCdpsStateData>(),
         isA<CommercioMintClosedCdpsStateLoading>(),

--- a/test/ui/mint/commercio_mint_ui_text_field_test.dart
+++ b/test/ui/mint/commercio_mint_ui_text_field_test.dart
@@ -35,7 +35,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioMintOpenedCdpStateInitial>(),
         isA<CommercioMintOpenedCdpStateLoading>(),
         isA<CommercioMintOpenedCdpStateData>(),
         isA<CommercioMintOpenedCdpStateLoading>(),
@@ -92,7 +91,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioMintDeriveCloseCdpStateInitial>(),
         isA<CommercioMintDeriveCloseCdpStateLoading>(),
         isA<CommercioMintDeriveCloseCdpStateData>(),
         isA<CommercioMintDeriveCloseCdpStateLoading>(),
@@ -151,7 +149,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioMintClosedCdpsStateInitial>(),
         isA<CommercioMintClosedCdpsStateLoading>(),
         isA<CommercioMintClosedCdpsStateData>(),
         isA<CommercioMintClosedCdpsStateLoading>(),

--- a/test/ui/mint/commercio_mint_ui_text_test.dart
+++ b/test/ui/mint/commercio_mint_ui_text_test.dart
@@ -35,7 +35,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioMintOpenedCdpStateInitial>(),
         isA<CommercioMintOpenedCdpStateLoading>(),
         isA<CommercioMintOpenedCdpStateData>(),
         isA<CommercioMintOpenedCdpStateLoading>(),
@@ -92,7 +91,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioMintDeriveCloseCdpStateInitial>(),
         isA<CommercioMintDeriveCloseCdpStateLoading>(),
         isA<CommercioMintDeriveCloseCdpStateData>(),
         isA<CommercioMintDeriveCloseCdpStateLoading>(),
@@ -151,7 +149,6 @@ void main() {
     expect(
       bloc,
       emitsInOrder([
-        isA<CommercioMintClosedCdpsStateInitial>(),
         isA<CommercioMintClosedCdpsStateLoading>(),
         isA<CommercioMintClosedCdpsStateData>(),
         isA<CommercioMintClosedCdpsStateLoading>(),


### PR DESCRIPTION
With the official release of the bloc 6.0 libraries the library can return to use the pre-release version.